### PR TITLE
탐색창, 글쓰기창, 내 프로필창, 상대 프로필창 ui 수정 완료.

### DIFF
--- a/lib/Widget/search/feed_widget.dart
+++ b/lib/Widget/search/feed_widget.dart
@@ -15,31 +15,34 @@ class FeedWidget extends GetView<MainController> {
 
   @override
   Widget build(BuildContext context) {
-    return InkWell(
-      borderRadius: BorderRadius.circular(24.0),
-      highlightColor: Theme.of(context).colorScheme.primaryContainer,
-      onTap: () {
-        _showApply(context);
-      },
-      child: Ink(
-        width: double.infinity,
-        decoration: BoxDecoration(
-          color: Theme.of(context).colorScheme.secondary,
-          borderRadius: BorderRadius.circular(24.0),
-          boxShadow: [
-            BoxShadow(
-              color: Theme.of(context).colorScheme.secondary.withOpacity(0.2),
-              spreadRadius: 5,
-              blurRadius: 7,
-              offset: const Offset(0, 6),
-            ),
-          ],
-        ),
-        child: Column(
-          children: [
-            _profile(horizontal: 10.0, vertical: 15.0),
-            _title(),
-          ],
+    return Card(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(24)),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(24.0),
+        highlightColor: Theme.of(context).colorScheme.primaryContainer,
+        onTap: () {
+          _showApply(context);
+        },
+        child: Ink(
+          width: double.infinity,
+          decoration: BoxDecoration(
+            color: Theme.of(context).colorScheme.secondary,
+            borderRadius: BorderRadius.circular(24.0),
+            boxShadow: [
+              BoxShadow(
+                color: Theme.of(context).colorScheme.secondary.withOpacity(0.2),
+                spreadRadius: 5,
+                blurRadius: 7,
+                offset: const Offset(0, 6),
+              ),
+            ],
+          ),
+          child: Column(
+            children: [
+              _profile(horizontal: 10.0, vertical: 15.0),
+              _title(),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/screen/profile/profile_screen.dart
+++ b/lib/screen/profile/profile_screen.dart
@@ -50,43 +50,64 @@ class ProfileScreen extends GetView<UserController> {
             physics: const BouncingScrollPhysics(),
             slivers: [
               _profile(),
-              // _personality(),
-              // _interesting(),
-              // _idealType(),
-              SliverToBoxAdapter(
-                child: Padding(
-                  padding: const EdgeInsets.only(top: 16.0, left: 8.0),
-                  child: Row(
+              SliverPadding(
+                padding: const EdgeInsets.symmetric(horizontal: 23.0),
+                sliver: SliverToBoxAdapter(
+                  child: Column(
                     children: [
-                      SizedBox(
-                        height: 50,
-                        width: 100,
-                        child: Card(
-                          shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(30),
-                          ),
-                          child: ClipRRect(
-                            borderRadius: BorderRadius.circular(30),
-                            child: Center(
-                              child: Text(
-                                '게시물',
-                                style: TextStyle(
-                                    fontWeight: FontWeight.w600,
-                                    fontSize: 24,
-                                    color: ThemeColor.fontColor),
+                      const SizedBox(height: 23),
+                      Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 7.0),
+                        child: Row(
+                          children: [
+                            Text(
+                              '내가 쓴 피드',
+                              style: TextStyle(
+                                fontSize: 19,
+                                fontWeight: FontWeight.w600,
+                                color: ThemeColor.fontColor,
                               ),
                             ),
-                          ),
+                          ],
                         ),
                       ),
+                      const SizedBox(height: 15),
                       Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 8.0),
-                        child: Text(
-                          '${FeedController.to.historys.length}개',
-                          style: TextStyle(
-                              fontWeight: FontWeight.w600,
-                              fontSize: 20,
-                              color: ThemeColor.fontColor),
+                        padding: const EdgeInsets.symmetric(horizontal: 7.0),
+                        child: Row(
+                          children: [
+                            SizedBox(
+                              child: Card(
+                                shape: RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(30),
+                                ),
+                                child: const Padding(
+                                  padding: EdgeInsets.symmetric(
+                                      horizontal: 16.0, vertical: 6.0),
+                                  child: Text(
+                                    '게시물',
+                                    textAlign: TextAlign.center,
+                                    style: TextStyle(
+                                      fontWeight: FontWeight.w600,
+                                      fontSize: 13,
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            ),
+                            Padding(
+                              padding:
+                                  const EdgeInsets.symmetric(horizontal: 8.0),
+                              child: Text(
+                                textAlign: TextAlign.center,
+                                '${FeedController.to.historys.length}개',
+                                style: const TextStyle(
+                                  fontWeight: FontWeight.w600,
+                                  fontSize: 13,
+                                ),
+                              ),
+                            ),
+                          ],
                         ),
                       ),
                     ],
@@ -154,7 +175,7 @@ class ProfileScreen extends GetView<UserController> {
           final Feed feed = FeedController.to.historys[index];
           return Padding(
             padding:
-                const EdgeInsets.symmetric(vertical: 14.0, horizontal: 16.0),
+                const EdgeInsets.symmetric(vertical: 14.0, horizontal: 23.0),
             child: FeedWidget(
               feed: feed,
               onTap: () => FeedController.to.showMyFeedOption(feed),
@@ -165,155 +186,4 @@ class ProfileScreen extends GetView<UserController> {
       ),
     );
   }
-
-  /// 내 인적사항을 보여줌
-  // Widget _info() => const SliverToBoxAdapter(
-  //       child: Column(
-  //         mainAxisAlignment: MainAxisAlignment.start,
-  //         crossAxisAlignment: CrossAxisAlignment.start,
-  //         children: [
-  //           Padding(
-  //             padding: EdgeInsets.symmetric(vertical: 10, horizontal: 20.0),
-  //             child: Text('인적사항'),
-  //           ),
-  //           Padding(
-  //             padding: EdgeInsets.symmetric(horizontal: 20.0),
-  //             child: Wrap(
-  //               direction: Axis.horizontal,
-  //               alignment: WrapAlignment.start,
-  //               spacing: 5,
-  //               runSpacing: 5,
-  //               children: [
-  //                 HobbyContainer(
-  //                   text: '일반대',
-  //                 ),
-  //                 HobbyContainer(
-  //                   text: '학생',
-  //                 ),
-  //                 HobbyContainer(
-  //                   text: 'ESTP',
-  //                 ),
-  //               ],
-  //             ),
-  //           ),
-  //         ],
-  //       ),
-  //     );
-
-  /// 내 성격을 보여줌
-  // Widget _personality() => const SliverToBoxAdapter(
-  //       child: Column(
-  //         mainAxisAlignment: MainAxisAlignment.start,
-  //         crossAxisAlignment: CrossAxisAlignment.start,
-  //         children: [
-  //           Padding(
-  //             padding: EdgeInsets.symmetric(vertical: 10, horizontal: 20.0),
-  //             child: Text('성격'),
-  //           ),
-  //           Padding(
-  //             padding: EdgeInsets.symmetric(horizontal: 20.0),
-  //             child: Wrap(
-  //               direction: Axis.horizontal,
-  //               alignment: WrapAlignment.start,
-  //               spacing: 5,
-  //               runSpacing: 5,
-  //               children: [
-  //                 HobbyContainer(
-  //                   text: '털털한',
-  //                 ),
-  //                 HobbyContainer(
-  //                   text: '기모띠',
-  //                 ),
-  //                 HobbyContainer(
-  //                   text: '자유로운',
-  //                 ),
-  //                 HobbyContainer(
-  //                   text: '유쾌한',
-  //                 ),
-  //                 HobbyContainer(
-  //                   text: '대담한',
-  //                 ),
-  //                 HobbyContainer(
-  //                   text: '보수적인',
-  //                 ),
-  //                 HobbyContainer(
-  //                   text: '재밌는',
-  //                 ),
-  //                 HobbyContainer(
-  //                   text: '호전적인',
-  //                 ),
-  //               ],
-  //             ),
-  //           ),
-  //         ],
-  //       ),
-  //     );
-
-  /// 내 관심사를 보여줌
-  // Widget _interesting() => const SliverToBoxAdapter(
-  //       child: Column(
-  //         mainAxisAlignment: MainAxisAlignment.start,
-  //         crossAxisAlignment: CrossAxisAlignment.start,
-  //         children: [
-  //           Padding(
-  //             padding: EdgeInsets.symmetric(vertical: 10, horizontal: 20.0),
-  //             child: Text('관심사'),
-  //           ),
-  //           Padding(
-  //             padding: EdgeInsets.symmetric(horizontal: 20.0),
-  //             child: Wrap(
-  //               direction: Axis.horizontal,
-  //               alignment: WrapAlignment.start,
-  //               spacing: 5,
-  //               runSpacing: 5,
-  //               children: [
-  //                 HobbyContainer(
-  //                   text: '게임',
-  //                 ),
-  //                 HobbyContainer(
-  //                   text: 'IT',
-  //                 ),
-  //                 HobbyContainer(
-  //                   text: '운동',
-  //                 ),
-  //               ],
-  //             ),
-  //           ),
-  //         ],
-  //       ),
-  //     );
-
-  /// 내 이상형을 보여줌
-  // Widget _idealType() => const SliverToBoxAdapter(
-  //       child: Column(
-  //         mainAxisAlignment: MainAxisAlignment.start,
-  //         crossAxisAlignment: CrossAxisAlignment.start,
-  //         children: [
-  //           Padding(
-  //             padding: EdgeInsets.symmetric(vertical: 10, horizontal: 20.0),
-  //             child: Text('이상형'),
-  //           ),
-  //           Padding(
-  //             padding: EdgeInsets.symmetric(horizontal: 20.0),
-  //             child: Wrap(
-  //               direction: Axis.horizontal,
-  //               alignment: WrapAlignment.start,
-  //               spacing: 5,
-  //               runSpacing: 5,
-  //               children: [
-  //                 HobbyContainer(
-  //                   text: '예쁜',
-  //                 ),
-  //                 HobbyContainer(
-  //                   text: '귀여운',
-  //                 ),
-  //                 HobbyContainer(
-  //                   text: '섹시한',
-  //                 ),
-  //               ],
-  //             ),
-  //           ),
-  //         ],
-  //       ),
-  //     );
 }

--- a/lib/screen/profile/profile_screen.dart
+++ b/lib/screen/profile/profile_screen.dart
@@ -23,6 +23,7 @@ class ProfileScreen extends GetView<UserController> {
   Widget build(BuildContext context) {
     return Obx(
       () => Scaffold(
+        backgroundColor: ThemeColor.grayBackground,
         appBar: PreferredSize(
           preferredSize: AppBar().preferredSize,
           child: CammitAppBar(

--- a/lib/screen/profile/profile_screen.dart
+++ b/lib/screen/profile/profile_screen.dart
@@ -51,71 +51,11 @@ class ProfileScreen extends GetView<UserController> {
             physics: const BouncingScrollPhysics(),
             slivers: [
               _profile(),
-              SliverPadding(
-                padding: const EdgeInsets.symmetric(horizontal: 23.0),
-                sliver: SliverToBoxAdapter(
-                  child: Column(
-                    children: [
-                      const SizedBox(height: 23),
-                      Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 7.0),
-                        child: Row(
-                          children: [
-                            Text(
-                              '내가 쓴 피드',
-                              style: TextStyle(
-                                fontSize: 19,
-                                fontWeight: FontWeight.w600,
-                                color: ThemeColor.fontColor,
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                      const SizedBox(height: 15),
-                      Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 7.0),
-                        child: Row(
-                          children: [
-                            SizedBox(
-                              child: Card(
-                                shape: RoundedRectangleBorder(
-                                  borderRadius: BorderRadius.circular(30),
-                                ),
-                                child: const Padding(
-                                  padding: EdgeInsets.symmetric(
-                                      horizontal: 16.0, vertical: 6.0),
-                                  child: Text(
-                                    '게시물',
-                                    textAlign: TextAlign.center,
-                                    style: TextStyle(
-                                      fontWeight: FontWeight.w600,
-                                      fontSize: 13,
-                                    ),
-                                  ),
-                                ),
-                              ),
-                            ),
-                            Padding(
-                              padding:
-                                  const EdgeInsets.symmetric(horizontal: 8.0),
-                              child: Text(
-                                textAlign: TextAlign.center,
-                                '${FeedController.to.historys.length}개',
-                                style: const TextStyle(
-                                  fontWeight: FontWeight.w600,
-                                  fontSize: 13,
-                                ),
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ),
+              _myFeedList(),
               Obx(() => (!controller.isLoading) ? _loading() : _myFeed()),
+              const SliverToBoxAdapter(
+                child: SizedBox(height: 100),
+              ),
             ],
           ),
         ),
@@ -162,6 +102,72 @@ class ProfileScreen extends GetView<UserController> {
           ),
         ),
       );
+
+  Widget _myFeedList() {
+    return SliverPadding(
+      padding: const EdgeInsets.symmetric(horizontal: 23.0),
+      sliver: SliverToBoxAdapter(
+        child: Column(
+          children: [
+            const SizedBox(height: 23),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 7.0),
+              child: Row(
+                children: [
+                  Text(
+                    '내가 쓴 피드',
+                    style: TextStyle(
+                      fontSize: 19,
+                      fontWeight: FontWeight.w600,
+                      color: ThemeColor.fontColor,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 15),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 7.0),
+              child: Row(
+                children: [
+                  SizedBox(
+                    child: Card(
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(30),
+                      ),
+                      child: const Padding(
+                        padding: EdgeInsets.symmetric(
+                            horizontal: 16.0, vertical: 6.0),
+                        child: Text(
+                          '게시물',
+                          textAlign: TextAlign.center,
+                          style: TextStyle(
+                            fontWeight: FontWeight.w600,
+                            fontSize: 13,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 8.0),
+                    child: Text(
+                      textAlign: TextAlign.center,
+                      '${FeedController.to.historys.length}개',
+                      style: const TextStyle(
+                        fontWeight: FontWeight.w600,
+                        fontSize: 13,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
 
   Widget _loading() => const SliverToBoxAdapter(
         child: Center(

--- a/lib/screen/profile/someone_profile_screen.dart
+++ b/lib/screen/profile/someone_profile_screen.dart
@@ -21,7 +21,7 @@ class SomeoneProfileScreen extends GetView<UserController> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Theme.of(context).colorScheme.secondary,
+      backgroundColor: ThemeColor.grayBackground,
       floatingActionButton: _fabs(context),
       floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
       body: SafeArea(
@@ -58,8 +58,10 @@ class SomeoneProfileScreen extends GetView<UserController> {
         ),
       ),
       backgroundColor: Get.theme.colorScheme.secondary,
-      systemOverlayStyle: SystemUiOverlayStyle(
-          statusBarColor: Theme.of(context).colorScheme.onSecondary),
+      systemOverlayStyle: const SystemUiOverlayStyle(
+        statusBarColor: Colors.transparent,
+        statusBarIconBrightness: Brightness.dark,
+      ),
       centerTitle: true,
       title: Text(
         "상대 프로필",

--- a/lib/screen/profile/someone_profile_screen.dart
+++ b/lib/screen/profile/someone_profile_screen.dart
@@ -1,3 +1,4 @@
+import 'package:dating/Widget/common/cammit_app_bar.dart';
 import 'package:dating/Widget/profile/user_profile_widget.dart';
 import 'package:dating/Widget/search/feed_widget.dart';
 import 'package:dating/controller/chat_controller.dart';
@@ -11,7 +12,6 @@ import 'package:dating/style/icon_shape.dart';
 import 'package:dating/widget/common/chat_send_button.dart';
 import 'package:dating/widget/common/favorite_button.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:get/get.dart';
 
 class SomeoneProfileScreen extends GetView<UserController> {
@@ -24,126 +24,97 @@ class SomeoneProfileScreen extends GetView<UserController> {
       backgroundColor: ThemeColor.grayBackground,
       floatingActionButton: _fabs(context),
       floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
+      appBar: PreferredSize(
+        preferredSize: AppBar().preferredSize,
+        child: CammitAppBar(
+          backAction: () => Get.back(),
+          title: "상대 프로필",
+          centerTitle: true,
+          showCloseButton: true,
+          actions: [
+            IconButton(
+              onPressed: () {
+                /// 우측 상단 ... 아이콘 누르면 바텀에서 차단/취소 여부 시트가 나옴
+                showModalBottomSheet(
+                  context: context,
+                  builder: (BuildContext context) {
+                    return Wrap(
+                      children: [
+                        Container(
+                          padding: const EdgeInsets.all(3.0),
+                          margin: const EdgeInsets.all(20),
+                          decoration: BoxDecoration(
+                            color: Colors.white,
+                            borderRadius: BorderRadius.circular(15),
+                          ),
+                          child: Center(
+                            child: Column(
+                              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                              children: [
+                                InkWell(
+                                  onTap: () async {
+                                    await MemberBlockController.to
+                                        .memberBlock(user.id!);
+                                  },
+                                  child: Container(
+                                    alignment: Alignment.center,
+                                    padding: const EdgeInsets.all(10.0),
+                                    width: double.infinity,
+                                    child: Text(
+                                      '차단',
+                                      style: TextStyle(
+                                        color: ThemeColor.fontColor,
+                                        fontSize: 17,
+                                        fontWeight: FontWeight.bold,
+                                      ),
+                                    ),
+                                  ),
+                                ),
+                                const Padding(
+                                  padding:
+                                      EdgeInsets.symmetric(horizontal: 10.0),
+                                  child: Divider(),
+                                ),
+                                InkWell(
+                                  child: Container(
+                                    alignment: Alignment.center,
+                                    padding: const EdgeInsets.all(10.0),
+                                    child: const Text(
+                                      '취소',
+                                      style: TextStyle(
+                                        color: Colors.black,
+                                        fontSize: 17,
+                                        fontWeight: FontWeight.bold,
+                                      ),
+                                    ),
+                                  ),
+                                  onTap: () {
+                                    Get.back();
+                                  },
+                                ),
+                              ],
+                            ),
+                          ),
+                        ),
+                      ],
+                    );
+                  },
+                  backgroundColor: Colors.transparent,
+                );
+              },
+              icon: IconShape.iconMore,
+            ),
+          ],
+        ),
+      ),
       body: SafeArea(
         child: CustomScrollView(
           slivers: [
-            _appbar(context),
             _profile(),
-            // _personality(),
-            // _interesting(),
-            // _idealType(),
-            // _storyHeader(),
-            // _story(),
             Obx(() => (!controller.isLoading) ? _loading() : _otherFeed()),
           ],
         ),
       ),
-    );
-  }
-
-  /// 커스텀 앱바를 제작
-  /// 앱바 우측 아이콘을 누르면
-  /// 사용자는 상대방을 차단/취소 가능.
-  Widget _appbar(context) {
-    return SliverAppBar(
-      elevation: 0.0,
-      floating: true,
-      leading: Padding(
-        padding: const EdgeInsets.all(8.0),
-        child: IconButton(
-          icon: IconShape.iconClose,
-          onPressed: () {
-            Get.back();
-          },
-        ),
-      ),
-      backgroundColor: Get.theme.colorScheme.secondary,
-      systemOverlayStyle: const SystemUiOverlayStyle(
-        statusBarColor: Colors.transparent,
-        statusBarIconBrightness: Brightness.dark,
-      ),
-      centerTitle: true,
-      title: Text(
-        "상대 프로필",
-        style: TextStyle(
-          fontSize: 25,
-          fontWeight: FontWeight.bold,
-          color: ThemeColor.fontColor,
-        ),
-      ),
-      actions: [
-        IconButton(
-          onPressed: () {
-            /// 우측 상단 ... 아이콘 누르면 바텀에서 차단/취소 여부 시트가 나옴
-            showModalBottomSheet(
-              context: context,
-              builder: (BuildContext context) {
-                return Wrap(
-                  children: [
-                    Container(
-                      padding: const EdgeInsets.all(3.0),
-                      margin: const EdgeInsets.all(20),
-                      decoration: BoxDecoration(
-                        color: Colors.white,
-                        borderRadius: BorderRadius.circular(15),
-                      ),
-                      child: Center(
-                        child: Column(
-                          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                          children: [
-                            InkWell(
-                              onTap: () async {
-                                await MemberBlockController.to
-                                    .memberBlock(user.id!);
-                              },
-                              child: Container(
-                                alignment: Alignment.center,
-                                padding: const EdgeInsets.all(10.0),
-                                width: double.infinity,
-                                child: Text(
-                                  '차단',
-                                  style: TextStyle(
-                                    color: ThemeColor.fontColor,
-                                    fontSize: 17,
-                                    fontWeight: FontWeight.bold,
-                                  ),
-                                ),
-                              ),
-                            ),
-                            const Padding(
-                              padding: EdgeInsets.symmetric(horizontal: 10.0),
-                              child: Divider(),
-                            ),
-                            InkWell(
-                              child: Container(
-                                alignment: Alignment.center,
-                                padding: const EdgeInsets.all(10.0),
-                                child: const Text(
-                                  '취소',
-                                  style: TextStyle(
-                                    color: Colors.black,
-                                    fontSize: 17,
-                                    fontWeight: FontWeight.bold,
-                                  ),
-                                ),
-                              ),
-                              onTap: () {
-                                Get.back();
-                              },
-                            ),
-                          ],
-                        ),
-                      ),
-                    ),
-                  ],
-                );
-              },
-              backgroundColor: Colors.transparent,
-            );
-          },
-          icon: IconShape.iconMore,
-        ),
-      ],
     );
   }
 

--- a/lib/screen/profile/someone_profile_screen.dart
+++ b/lib/screen/profile/someone_profile_screen.dart
@@ -112,6 +112,9 @@ class SomeoneProfileScreen extends GetView<UserController> {
           slivers: [
             _profile(),
             Obx(() => (!controller.isLoading) ? _loading() : _otherFeed()),
+            const SliverToBoxAdapter(
+              child: SizedBox(height: 100),
+            ),
           ],
         ),
       ),

--- a/lib/screen/search/feed_write_screen.dart
+++ b/lib/screen/search/feed_write_screen.dart
@@ -1,10 +1,11 @@
+import 'package:dating/Widget/search/feed_widget.dart';
 import 'package:dating/controller/feed_controller.dart';
 import 'package:dating/data/model/feed.dart';
+import 'package:dating/style/constant.dart';
 import 'package:dating/widget/common/bottom_button.dart';
 import 'package:dating/widget/common/cammit_app_bar.dart';
-import 'package:dotted_border/dotted_border.dart';
 import 'package:flutter/material.dart';
-import 'package:get/get.dart';
+import 'package:get/get_core/src/get_main.dart';
 
 class FeedWriteScreen extends StatefulWidget {
   final Feed? feed;
@@ -52,7 +53,23 @@ class _FeedWriteScreenState extends State<FeedWriteScreen> {
             mainAxisAlignment: MainAxisAlignment.start,
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
+              const Padding(
+                padding: EdgeInsets.only(
+                    left: 33.0, right: 33.0, top: 30, bottom: 10),
+                child: Text(
+                  '제목',
+                  style: TextStyle(fontSize: 12),
+                ),
+              ),
               _titleWrite(),
+              const Padding(
+                padding: EdgeInsets.only(
+                    left: 33.0, right: 33.0, top: 30, bottom: 10),
+                child: Text(
+                  '당신의 이야기를 공유해보세요',
+                  style: TextStyle(fontSize: 12),
+                ),
+              ),
               _sub(),
             ],
           ),
@@ -63,29 +80,32 @@ class _FeedWriteScreenState extends State<FeedWriteScreen> {
   /// 제목 쓰기 칸(title)
   Widget _titleWrite() {
     return Padding(
-      padding: const EdgeInsets.all(8.0),
-      child: DottedBorder(
-        strokeWidth: 2,
-        color: Colors.grey,
-        borderType: BorderType.RRect,
-        radius: const Radius.circular(10),
-        dashPattern: const [5, 5],
-        child: SizedBox(
-          height: Get.size.width * 0.15,
-          width: Get.size.width * 1,
-          child: Padding(
-            padding: const EdgeInsets.all(8.0),
-            child: TextField(
-              controller: _titleController,
-              maxLength: 50,
-              maxLines: 1,
-              decoration: const InputDecoration(
-                hintText: '제목을 작성해주세요.',
-                border: InputBorder.none,
-                counterText: '',
-              ),
-              onChanged: FeedController.to.titleChange,
+      padding: const EdgeInsets.only(left: 33.0, right: 33.0, bottom: 10),
+      child: Container(
+        height: 60,
+        width: double.infinity,
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(10),
+          color: ThemeColor.practice,
+        ),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 11.0, vertical: 17.0),
+          child: TextField(
+            controller: _titleController,
+            maxLength: 20,
+            maxLines: 1,
+            keyboardType: TextInputType.multiline,
+            style: const TextStyle(color: Colors.black),
+            decoration: const InputDecoration(
+              hintText: '제목을 작성해주세요.',
+              hintStyle: TextStyle(fontSize: 12),
+              border: InputBorder.none,
+              counterText: '',
             ),
+            onChanged: FeedController.to.titleChange,
+            textInputAction: TextInputAction.done,
+            scrollPhysics: const BouncingScrollPhysics(),
+            scrollPadding: const EdgeInsets.all(0),
           ),
         ),
       ),
@@ -95,32 +115,31 @@ class _FeedWriteScreenState extends State<FeedWriteScreen> {
   /// 세부 글 작성 칸(sub)
   Widget _sub() {
     return Padding(
-      padding: const EdgeInsets.all(8.0),
-      child: DottedBorder(
-        strokeWidth: 2,
-        color: Colors.grey,
-        borderType: BorderType.RRect,
-        radius: const Radius.circular(10),
-        dashPattern: const [5, 5],
-        child: Container(
-          width: Get.size.width * 1,
-          constraints: BoxConstraints(
-            minHeight: Get.size.width * 0.15,
-          ),
-          child: Padding(
-            padding: const EdgeInsets.all(8.0),
-            child: TextField(
-              controller: _contentController,
-              maxLength: 50,
-              minLines: 5,
-              maxLines: null,
-              decoration: const InputDecoration(
-                hintText: '글을 작성해주세요.',
-                border: InputBorder.none,
-                counterText: '',
-              ),
-              onChanged: FeedController.to.contentChange,
+      padding: const EdgeInsets.only(left: 33.0, right: 33.0, bottom: 10),
+      child: Container(
+        height: 300,
+        width: double.infinity,
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(10),
+          color: ThemeColor.practice,
+        ),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 11.0, vertical: 17.0),
+          child: TextField(
+            textAlignVertical: const TextAlignVertical(y: -1),
+            controller: _contentController,
+            maxLength: 255,
+            expands: true,
+            maxLines: null,
+            minLines: null,
+            keyboardType: TextInputType.multiline,
+            decoration: const InputDecoration(
+              hintText: '글을 작성해주세요.',
+              hintStyle: TextStyle(fontSize: 12),
+              border: InputBorder.none,
+              counterText: '',
             ),
+            onChanged: FeedController.to.contentChange,
           ),
         ),
       ),
@@ -130,26 +149,31 @@ class _FeedWriteScreenState extends State<FeedWriteScreen> {
   /// 처음 글 작성을 완료한 후,
   /// 이 버튼을 누르면 탐색 창에서 작성한 글이 올라감.
   Widget _completeButton() {
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 20.0, vertical: 30.0),
-      child: SafeArea(
-        bottom: true,
-        child: BottomButton(
-          onTap: () {
-            if (widget.feed != null) {
-              Feed updatedFeed = Feed(
-                  id: widget.feed!.id,
-                  title: _titleController.text,
-                  content: _contentController.text);
-              FeedController.to.updateDialog(updatedFeed);
-            } else {
-              FeedController.to.completeFeed();
-            }
-          },
-          child: const Text(
-            "작성 완료",
-            style: TextStyle(
-                color: Colors.white, fontSize: 18, fontWeight: FontWeight.w600),
+    return Container(
+      color: Colors.white,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 33.0, vertical: 35.0),
+        child: SafeArea(
+          bottom: true,
+          child: BottomButton(
+            onTap: () {
+              if (widget.feed != null) {
+                Feed updatedFeed = Feed(
+                    id: widget.feed!.id,
+                    title: _titleController.text,
+                    content: _contentController.text);
+                FeedController.to.updateDialog(updatedFeed);
+              } else {
+                FeedController.to.completeFeed();
+              }
+            },
+            child: const Text(
+              "작성 완료",
+              style: TextStyle(
+                  color: Colors.white,
+                  fontSize: 16,
+                  fontWeight: FontWeight.bold),
+            ),
           ),
         ),
       ),

--- a/lib/screen/search/feed_write_screen.dart
+++ b/lib/screen/search/feed_write_screen.dart
@@ -1,11 +1,9 @@
-import 'package:dating/Widget/search/feed_widget.dart';
 import 'package:dating/controller/feed_controller.dart';
 import 'package:dating/data/model/feed.dart';
 import 'package:dating/style/constant.dart';
 import 'package:dating/widget/common/bottom_button.dart';
 import 'package:dating/widget/common/cammit_app_bar.dart';
 import 'package:flutter/material.dart';
-import 'package:get/get_core/src/get_main.dart';
 
 class FeedWriteScreen extends StatefulWidget {
   final Feed? feed;
@@ -86,7 +84,7 @@ class _FeedWriteScreenState extends State<FeedWriteScreen> {
         width: double.infinity,
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(10),
-          color: ThemeColor.practice,
+          color: ThemeColor.inputTextColor,
         ),
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 11.0, vertical: 17.0),
@@ -121,7 +119,7 @@ class _FeedWriteScreenState extends State<FeedWriteScreen> {
         width: double.infinity,
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(10),
-          color: ThemeColor.practice,
+          color: ThemeColor.inputTextColor,
         ),
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 11.0, vertical: 17.0),

--- a/lib/screen/search/search_screen.dart
+++ b/lib/screen/search/search_screen.dart
@@ -1,3 +1,4 @@
+import 'package:dating/style/constant.dart';
 import 'package:dating/widget/common/image_data.dart';
 import 'package:dating/Widget/search/feed_widget.dart';
 import 'package:dating/controller/feed_controller.dart';
@@ -14,6 +15,7 @@ class SearchScreen extends GetView<FeedController> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      backgroundColor: ThemeColor.grayBackground,
       appBar: _appBar(),
       body: Obx(() => (controller.isLoading) ? _loading() : _body()),
     );

--- a/lib/style/constant.dart
+++ b/lib/style/constant.dart
@@ -13,4 +13,5 @@ class ThemeColor {
   static Color get iconColor => const Color.fromARGB(255, 179, 177, 177);
   static Color get textfieldFill => const Color(0xffefefef);
   static Color get textfieldText => const Color(0xffafafaf);
+  static Color get practice => const Color(0xffEDEDED);
 }

--- a/lib/style/constant.dart
+++ b/lib/style/constant.dart
@@ -13,5 +13,6 @@ class ThemeColor {
   static Color get iconColor => const Color.fromARGB(255, 179, 177, 177);
   static Color get textfieldFill => const Color(0xffefefef);
   static Color get textfieldText => const Color(0xffafafaf);
-  static Color get practice => const Color(0xffEDEDED);
+  static Color get inputTextColor => const Color(0xffEDEDED);
+  static Color get grayBackground => const Color(0xffF4F4F4);
 }


### PR DESCRIPTION
프로필창 헤더 수정 완료.
글쓰기창 ui notion 디자인 변경대로 수정.
탐색창, 내 프로필창 백그라운드 색 white-> gray로 변경. 피드 박스에 그림자 줌.
상대 프로필창 상태바와 appbar 색이 달라지는 문제 때문에 sliver appbar을 지우고, cammitappbar widget 사용.
Solved Conflict Error by SangWook’s code for pr.
내 프로필창과 상대 프로필창에 바텀네비 때문에 피드가 가려지는 걸 방지하기 위해 sizedbox를 통해 여백을 줌.